### PR TITLE
fix: CDK infrastructure improvements

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python3
-import os
-
 import aws_cdk as cdk
 from aws_cdk import Aspects
 from cdk_nag import AwsSolutionsChecks
 
-
 from dyndns.dyndns_stack import DyndnsStack
-
 
 app = cdk.App()
 DyndnsStack(app, "DyndnsStack")

--- a/dyndns/dyndns_stack.py
+++ b/dyndns/dyndns_stack.py
@@ -1,57 +1,62 @@
 import aws_cdk as cdk
-import aws_cdk.aws_s3 as s3
 import aws_cdk.aws_lambda as lambda_
 import aws_cdk.aws_dynamodb as dynamodb
 import aws_cdk.aws_iam as iam
-from cdk_nag import AwsSolutionsChecks, NagSuppressions, NagPackSuppression
+import aws_cdk.aws_logs as logs
+from cdk_nag import NagSuppressions, NagPackSuppression
+
 
 class DyndnsStack(cdk.Stack):
 
     def __init__(self, scope: cdk.App, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
-     
-        
-        #Create dynamoDB table
+
+        # Create DynamoDB table
         table = dynamodb.Table(self, "dyndns_db",
-            partition_key=dynamodb.Attribute(name="hostname", type=dynamodb.AttributeType.STRING),
-            removal_policy=cdk.RemovalPolicy.DESTROY,
-            point_in_time_recovery=True                   
+            partition_key=dynamodb.Attribute(
+                name="hostname", type=dynamodb.AttributeType.STRING,
+            ),
+            removal_policy=cdk.RemovalPolicy.RETAIN,
+            point_in_time_recovery=True,
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
         )
-        
-        #Create Lambda role
+
+        # Create Lambda role
         fn_role = iam.Role(self, "dyndns_fn_role",
-            assumed_by = iam.ServicePrincipal("lambda.amazonaws.com"),
-            description = "DynamicDNS Lambda role",
-            inline_policies = {
-                'r53': iam.PolicyDocument(
-                    statements = [
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+            description="DynamicDNS Lambda role",
+            inline_policies={
+                "r53": iam.PolicyDocument(
+                    statements=[
                         iam.PolicyStatement(
-                            effect = iam.Effect.ALLOW,
-                            resources = [
-                                "*"
+                            effect=iam.Effect.ALLOW,
+                            resources=["arn:aws:route53:::hostedzone/*"],
+                            actions=[
+                                "route53:ChangeResourceRecordSets",
+                                "route53:ListResourceRecordSets",
                             ],
-                          actions = [
-                                "route53:ChangeResourceRecordSets","route53:ListResourceRecordSets"
-                            ]
-                        )
+                        ),
                     ],
                 ),
-                'cw': iam.PolicyDocument(
-                    statements = [
+                "cw": iam.PolicyDocument(
+                    statements=[
                         iam.PolicyStatement(
-                            effect = iam.Effect.ALLOW,
-                            resources = [
-                                "*"
+                            effect=iam.Effect.ALLOW,
+                            resources=[
+                                cdk.Fn.sub(
+                                    "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+                                ),
                             ],
-                          actions = [
-                                "logs:CreateLogGroup","logs:CreateLogStream","logs:PutLogEvents"
-                            ]
-                        )
+                            actions=[
+                                "logs:CreateLogGroup",
+                                "logs:CreateLogStream",
+                                "logs:PutLogEvents",
+                            ],
+                        ),
                     ],
-                )
-            }
-        ) 
-
+                ),
+            },
+        )
 
         fn = lambda_.Function(self, "dyndns_fn",
             runtime=lambda_.Runtime.PYTHON_3_14,
@@ -60,36 +65,37 @@ class DyndnsStack(cdk.Stack):
             code=lambda_.Code.from_asset("lambda"),
             role=fn_role,
             timeout=cdk.Duration.seconds(8),
-            #Provide DynammoDB table name as enviroment variable
+            reserved_concurrent_executions=10,
+            log_retention=logs.RetentionDays.ONE_MONTH,
             environment={
-                "ddns_config_table":table.table_name
-            }
-        )            
-
-        #Create FunctionURL for invocation - principal will be set to * as it required for invocation from any HTTP client
-        fn.add_function_url(
-            #Allow unauthenticated access
-            auth_type=lambda_.FunctionUrlAuthType.NONE,
-            #Set CORS for any source
-            cors=lambda_.FunctionUrlCorsOptions(
-                allowed_origins=["*"]
-            )
+                "ddns_config_table": table.table_name,
+            },
         )
 
-        #Give lambda permissions to read DynamoDB table
+        # Create FunctionURL for invocation
+        fn.add_function_url(
+            auth_type=lambda_.FunctionUrlAuthType.NONE,
+            cors=lambda_.FunctionUrlCorsOptions(
+                allowed_origins=["*"],
+            ),
+        )
+
+        # Give Lambda permissions to read DynamoDB table
         table.grant_read_data(fn)
 
-        #Suppress AwsSolutions-IAM5 triggered by Resources::*
+        # Suppress AwsSolutions-IAM5 for wildcard resources
         NagSuppressions.add_resource_suppressions(
-            construct= fn_role,
+            construct=fn_role,
             suppressions=[
                 NagPackSuppression(
-                    id = 'AwsSolutions-IAM5',
-                    reason="""
-                    Lambda role created at line 29 has 2 inline policies allowing access to Route53 and CloudWatch. 
-                    Route53 resources are set to "*" as the function will need to access any hosted zone.
-                    CloudWatch resources are set to "*" to avoid having to specify a Logging group and consume the default one deployed by CDK.
-                    """
-                )
-            ]
+                    id="AwsSolutions-IAM5",
+                    reason="Route53 resources use hostedzone/* as the function needs access to any hosted zone. "
+                           "CloudWatch Logs resources use /aws/lambda/* pattern.",
+                    applies_to=[
+                        "Resource::arn:aws:route53:::hostedzone/*",
+                        "Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/*",
+                    ],
+                ),
+            ],
+            apply_to_children=True,
         )


### PR DESCRIPTION
## Summary

- IAM ポリシーのリソース制限を強化（Route53, CloudWatch Logs）
- DynamoDB の RemovalPolicy を RETAIN に変更し、課金モードを PAY_PER_REQUEST に変更
- Lambda のログ保持期間と reserved concurrency を設定
- 未使用インポートの削除、CDK-Nag サプレッションの改善

## Test Plan

- [x] 構文チェック成功
- [x] 既存テスト PASS
- [x] `cdk synth` / `cdk diff` で検証
- [x] `cdk deploy` 後に動作確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)