### PR TITLE
test: add CDK stack and Lambda unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+import os
+
+# lambda/ ディレクトリを sys.path に追加して Lambda コードをインポート可能にする
+# "lambda" は Python 予約語のため、パッケージとしてインポートできない
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lambda"))

--- a/tests/unit/test_dyndns_stack.py
+++ b/tests/unit/test_dyndns_stack.py
@@ -1,15 +1,98 @@
-import aws_cdk as core
+import aws_cdk as cdk
 import aws_cdk.assertions as assertions
+from aws_cdk import Aspects
+from cdk_nag import AwsSolutionsChecks
 
 from dyndns.dyndns_stack import DyndnsStack
 
-# example tests. To run these tests, uncomment this file along with the example
-# resource in dyndns/dyndns_stack.py
-def test_sqs_queue_created():
-    app = core.App()
-    stack = DyndnsStack(app, "dyndns")
-    template = assertions.Template.from_stack(stack)
 
-#     template.has_resource_properties("AWS::SQS::Queue", {
-#         "VisibilityTimeout": 300
-#     })
+def _create_template():
+    app = cdk.App()
+    stack = DyndnsStack(app, "TestDyndnsStack")
+    Aspects.of(app).add(AwsSolutionsChecks(verbose=True))
+    return assertions.Template.from_stack(stack)
+
+
+def test_dynamodb_table_created():
+    template = _create_template()
+    template.has_resource_properties("AWS::DynamoDB::Table", {
+        "KeySchema": [{"AttributeName": "hostname", "KeyType": "HASH"}],
+        "BillingMode": "PAY_PER_REQUEST",
+        "PointInTimeRecoverySpecification": {"PointInTimeRecoveryEnabled": True},
+    })
+
+
+def test_dynamodb_table_retained():
+    template = _create_template()
+    template.has_resource("AWS::DynamoDB::Table", {
+        "DeletionPolicy": "Retain",
+        "UpdateReplacePolicy": "Retain",
+    })
+
+
+def test_lambda_function_properties():
+    template = _create_template()
+    template.has_resource_properties("AWS::Lambda::Function", {
+        "Runtime": "python3.14",
+        "Architectures": ["arm64"],
+        "Handler": "index.lambda_handler",
+        "Timeout": 8,
+        "ReservedConcurrentExecutions": 10,
+    })
+
+
+def test_lambda_function_url():
+    template = _create_template()
+    template.has_resource_properties("AWS::Lambda::Url", {
+        "AuthType": "NONE",
+        "Cors": {"AllowOrigins": ["*"]},
+    })
+
+
+def test_lambda_has_dynamodb_read_policy():
+    template = _create_template()
+    template.has_resource_properties("AWS::IAM::Policy", {
+        "PolicyDocument": assertions.Match.object_like({
+            "Statement": assertions.Match.array_with([
+                assertions.Match.object_like({
+                    "Action": assertions.Match.array_with([
+                        "dynamodb:BatchGetItem",
+                        "dynamodb:GetItem",
+                    ]),
+                    "Effect": "Allow",
+                }),
+            ]),
+        }),
+    })
+
+
+def test_iam_role_has_route53_policy():
+    template = _create_template()
+    template.has_resource_properties("AWS::IAM::Role", {
+        "Policies": assertions.Match.array_with([
+            assertions.Match.object_like({
+                "PolicyName": "r53",
+                "PolicyDocument": assertions.Match.object_like({
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Resource": "arn:aws:route53:::hostedzone/*",
+                        "Action": [
+                            "route53:ChangeResourceRecordSets",
+                            "route53:ListResourceRecordSets",
+                        ],
+                    }],
+                }),
+            }),
+        ]),
+    })
+
+
+def test_iam_role_has_cloudwatch_policy():
+    template = _create_template()
+    template.has_resource_properties("AWS::IAM::Role", {
+        "Policies": assertions.Match.array_with([
+            assertions.Match.object_like({
+                "PolicyName": "cw",
+            }),
+        ]),
+    })

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -1,0 +1,244 @@
+import json
+import hashlib
+import importlib
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+@pytest.fixture()
+def lambda_module():
+    """Lambda モジュールをモック化された boto3 クライアントでロードする。"""
+    mock_dynamodb = MagicMock()
+    mock_r53 = MagicMock()
+
+    def client_factory(service, **kwargs):
+        if service == "dynamodb":
+            return mock_dynamodb
+        if service == "route53":
+            return mock_r53
+        return MagicMock()
+
+    with patch("boto3.client", side_effect=client_factory):
+        import index as mod
+        importlib.reload(mod)
+        yield {
+            "handler": mod.lambda_handler,
+            "dynamodb": mock_dynamodb,
+            "r53": mock_r53,
+        }
+
+
+def _make_event(body=None, source_ip="203.0.113.1"):
+    """Lambda Function URL イベントを生成するヘルパー。"""
+    return {
+        "body": json.dumps(body) if body is not None else None,
+        "requestContext": {
+            "http": {
+                "sourceIp": source_ip,
+                "method": "POST",
+                "path": "/",
+                "protocol": "HTTP/1.1",
+            },
+        },
+    }
+
+
+def _make_hash(ip, hostname, secret):
+    return hashlib.sha256(f"{ip}{hostname}{secret}".encode("utf-8")).hexdigest()
+
+
+def _setup_dynamodb_config(mock_ddb, hostname="test.example.com",
+                           zone_id="Z12345", ttl=60, secret="mysecret"):
+    mock_ddb.get_item.return_value = {
+        "Item": {
+            "hostname": {"S": hostname},
+            "data": {"S": json.dumps({
+                "route_53_zone_id": zone_id,
+                "route_53_record_ttl": ttl,
+                "shared_secret": secret,
+            })},
+        },
+    }
+
+
+def _setup_route53_get(mock_r53, hostname="test.example.com", ip="10.0.0.1"):
+    mock_r53.list_resource_record_sets.return_value = {
+        "ResourceRecordSets": [{
+            "Name": f"{hostname}.",
+            "Type": "A",
+            "TTL": 60,
+            "ResourceRecords": [{"Value": ip}],
+        }],
+    }
+
+
+class TestGetMode:
+    def test_returns_source_ip(self, lambda_module):
+        event = _make_event({"execution_mode": "get"}, source_ip="203.0.113.1")
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["return_status"] == "success"
+        assert body["return_message"] == "203.0.113.1"
+
+
+class TestSetModeSuccess:
+    def test_successful_update(self, lambda_module):
+        mock_ddb = lambda_module["dynamodb"]
+        mock_r53 = lambda_module["r53"]
+        _setup_dynamodb_config(mock_ddb)
+        _setup_route53_get(mock_r53, ip="10.0.0.1")
+        mock_r53.change_resource_record_sets.return_value = {}
+
+        ip = "203.0.113.1"
+        h = _make_hash(ip, "test.example.com", "mysecret")
+        event = _make_event({
+            "execution_mode": "set",
+            "ddns_hostname": "test.example.com",
+            "validation_hash": h,
+        }, source_ip=ip)
+
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 201
+        body = json.loads(result["body"])
+        assert body["return_status"] == "success"
+        assert "updated" in body["return_message"]
+
+    def test_ip_already_matches(self, lambda_module):
+        mock_ddb = lambda_module["dynamodb"]
+        mock_r53 = lambda_module["r53"]
+        ip = "203.0.113.1"
+        _setup_dynamodb_config(mock_ddb)
+        _setup_route53_get(mock_r53, ip=ip)
+
+        h = _make_hash(ip, "test.example.com", "mysecret")
+        event = _make_event({
+            "execution_mode": "set",
+            "ddns_hostname": "test.example.com",
+            "validation_hash": h,
+        }, source_ip=ip)
+
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["return_status"] == "success"
+        assert "matches" in body["return_message"]
+
+
+class TestValidation:
+    def test_invalid_json_body(self, lambda_module):
+        event = {
+            "body": "not json",
+            "requestContext": {"http": {"sourceIp": "1.2.3.4"}},
+        }
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 400
+        body = json.loads(result["body"])
+        assert "Invalid" in body["return_message"]
+
+    def test_none_body(self, lambda_module):
+        event = _make_event(None)
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 400
+
+    def test_empty_body(self, lambda_module):
+        event = {"body": "", "requestContext": {"http": {"sourceIp": "1.2.3.4"}}}
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 400
+
+    def test_invalid_execution_mode(self, lambda_module):
+        event = _make_event({"execution_mode": "delete"})
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 400
+
+    def test_missing_execution_mode(self, lambda_module):
+        event = _make_event({})
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 400
+
+    def test_missing_hostname_in_set(self, lambda_module):
+        event = _make_event({
+            "execution_mode": "set",
+            "validation_hash": "a" * 64,
+        })
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 400
+
+    def test_missing_validation_hash_in_set(self, lambda_module):
+        event = _make_event({
+            "execution_mode": "set",
+            "ddns_hostname": "test.example.com",
+        })
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 400
+
+    def test_invalid_hash_format(self, lambda_module):
+        mock_ddb = lambda_module["dynamodb"]
+        _setup_dynamodb_config(mock_ddb)
+        event = _make_event({
+            "execution_mode": "set",
+            "ddns_hostname": "test.example.com",
+            "validation_hash": "not-a-valid-hash",
+        })
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 400
+
+    def test_hash_too_long(self, lambda_module):
+        """re.fullmatch が re.match の前方一致問題を修正していることを検証。"""
+        mock_ddb = lambda_module["dynamodb"]
+        _setup_dynamodb_config(mock_ddb)
+        event = _make_event({
+            "execution_mode": "set",
+            "ddns_hostname": "test.example.com",
+            "validation_hash": "a" * 65,
+        })
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 400
+
+
+class TestAuth:
+    def test_hash_mismatch(self, lambda_module):
+        mock_ddb = lambda_module["dynamodb"]
+        _setup_dynamodb_config(mock_ddb)
+        event = _make_event({
+            "execution_mode": "set",
+            "ddns_hostname": "test.example.com",
+            "validation_hash": "a" * 64,
+        })
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 401
+
+    def test_config_not_found(self, lambda_module):
+        mock_ddb = lambda_module["dynamodb"]
+        mock_ddb.get_item.return_value = {}
+        event = _make_event({
+            "execution_mode": "set",
+            "ddns_hostname": "unknown.example.com",
+            "validation_hash": "a" * 64,
+        })
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 403
+
+
+class TestRoute53Errors:
+    def test_route53_get_error(self, lambda_module):
+        from botocore.exceptions import ClientError
+        mock_ddb = lambda_module["dynamodb"]
+        mock_r53 = lambda_module["r53"]
+        _setup_dynamodb_config(mock_ddb)
+        mock_r53.list_resource_record_sets.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchHostedZone", "Message": "Not found"}},
+            "ListResourceRecordSets",
+        )
+
+        ip = "203.0.113.1"
+        h = _make_hash(ip, "test.example.com", "mysecret")
+        event = _make_event({
+            "execution_mode": "set",
+            "ddns_hostname": "test.example.com",
+            "validation_hash": h,
+        }, source_ip=ip)
+
+        result = lambda_module["handler"](event, None)
+        assert result["statusCode"] == 500


### PR DESCRIPTION
## Summary

- テスト未実装（アサーション全コメントアウト）を全面書き直し
- CDK スタックテスト 7 件 + Lambda ユニットテスト 15 件 = 計 22 テスト
- GET/SET 正常系、バリデーション、認証、エラーハンドリングをカバー

## Test Plan

- [x] `pytest tests/ -v` で 22 テスト全 PASS

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)