### PR TITLE
docs: document managerecord.py in README and invocation.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,71 @@ _newrecord.py_ provides all the flags to successfully run the script:
 ```
 
 More information on how to invoke the Lambda URL can be found here: [invocation.md](invocation.md)
+
+## Managing DNS Records
+
+To view, update, or delete an existing DNS record configuration, use the included [managerecord.py](managerecord.py) script.
+(Execute this script for each hostname to be managed)
+
+> `python3 managerecord.py <subcommand> <hostname>`
+
+The DynamoDB table name is resolved automatically from the CloudFormation stack — no manual lookup is required.
+
+### Show the current configuration
+
+> `python3 managerecord.py show www.example.com`
+
+The script will display the DynamoDB configuration and the current Route 53 record:
+
+```
+Hostname        : www.example.com
+Hosted zone ID  : ZYZ12345678901234
+TTL             : 60
+Secret          : ********
+Current IP      : 203.0.113.1
+Route 53 TTL    : 60
+```
+
+### Update TTL immediately
+
+The Lambda function only updates the Route 53 record when the public IP address changes. If the TTL is changed in DynamoDB via [newrecord.py](newrecord.py), the new value is not reflected in Route 53 until the next IP change.
+
+To apply a new TTL right away without waiting for an IP change:
+
+> `python3 managerecord.py update-ttl www.example.com 300`
+
+The script will display the current and new TTL, then prompt for confirmation:
+
+```
+Hostname        : www.example.com
+Current TTL     : 60  -->  New TTL: 300
+Current IP      : 203.0.113.1
+
+Do you want to continue? (y/n)
+```
+
+Type `y` to update both the Route 53 record and the DynamoDB configuration.
+
+### Delete a record
+
+To delete the DynamoDB configuration only:
+
+> `python3 managerecord.py delete www.example.com`
+
+To delete both the DynamoDB configuration and the Route 53 DNS record:
+
+> `python3 managerecord.py delete --also-route53 www.example.com`
+
+The script will display the record to be deleted and prompt for confirmation before making any changes:
+
+```
+Hostname        : www.example.com
+Hosted zone ID  : ZYZ12345678901234
+Route 53 record will also be deleted.
+
+Do you want to continue? (y/n)
+```
+
+Type `y` to confirm.
+
+> If the DynamoDB record has already been deleted, running `delete --also-route53` will still locate and remove the Route 53 record by resolving the hosted zone from the hostname.

--- a/invocation.md
+++ b/invocation.md
@@ -140,6 +140,10 @@ If the hostname already matches the public IP it will return:
 ```
 
 - **Validate the DynamoDB configuration**\
+    Use [managerecord.py](managerecord.py) to inspect the stored configuration:
+
+    > `python3 managerecord.py show www.example.com`
+
     Is the configuration present for "www.example.com"?\
     Is the _hostname_ attribute typed correctly?\
     Does the _data_ attribute contain a valid **JSON** configuration (i.e. [www.example.com.json](www.example.com.json)) ?
@@ -193,6 +197,10 @@ A new configuration can be created using [newrecord.py](newrecord.py)
 > **_An error occurred (NoSuchHostedZone) when calling the ListResourceRecordSets operation: No hosted zone found with ID: Z123456ABABO1ABC10A_**
 
 The Host Zone ID (i.e. `Z123456ABABO1ABC10A`) is incorrect, if the Hosted Zone ID doesn't exist, create it, if it exists verify that the Hosted Zone ID is correctly saved in the DynamoDB configuration.
+
+Use [managerecord.py](managerecord.py) to inspect the stored Hosted Zone ID:
+
+> `python3 managerecord.py show www.example.com`
 
 A new configuration can be created using [newrecord.py](newrecord.py)
 


### PR DESCRIPTION
## Summary

- README.md に「Managing DNS Records」セクションを追加し、`show` / `update-ttl` / `delete` の使い方をサンプル出力・確認プロンプト例とともに記載
- invocation.md のトラブルシューティングセクション（403・500 NoSuchHostedZone）に `managerecord.py show` を使った設定確認方法を追記

Closes #15

## Test plan

- [x] README の「Managing DNS Records」セクションが読んで分かる内容になっている
- [x] invocation.md の 403・500 トラブルシューティングに `managerecord.py show` の案内が記載されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)